### PR TITLE
Add CPU demo to spectre article

### DIFF
--- a/site/spectre/index.luax
+++ b/site/spectre/index.luax
@@ -114,6 +114,175 @@ return "]]..timingMessageSuccess..[["
   </div>
 end
 
+
+function CPUDemo()
+  return  <div id="timing-demo-cpu" class="timing-demo flex flex-column g2">
+            <div class="flex g2 items-stretch">
+              <div class="flex flex-column g2 ba pa3 br3 overflow-hidden">
+                <h3 class="mt0">CPU</h3>
+                <form class="flex flex-column g2">
+                  <div>
+                    <input class="ph2 pv1" id="cpu-secret-index" type="number" min="0" max="3" placeholder="Secret Index" />
+                    <input type="submit" class="ph2 pv1" id="cpu-lookup" value="Lookup" />
+                  </div>
+                  <input type="submit" class="ph2 pv1" id="cpu-probe" value="Probe ProbeArray" />
+                  <input type="submit" class="ph2 pv1" id="cpu-clear-cache" value="Clear CPU Cache" />
+                  <div class="mt6-ns">
+                    <input id="cpu-vault-0" type="number" min="0" max="9" class="ph2 pv1 w3-ns" />
+                    <input id="cpu-vault-1" type="number" min="0" max="9" class="ph2 pv1 w3-ns" />
+                    <input id="cpu-vault-2" type="number" min="0" max="9" class="ph2 pv1 w3-ns" />
+                    <input id="cpu-vault-3" type="number" min="0" max="9" class="ph2 pv1 w3-ns" />
+                    <input type="submit" class="ph2 pv1" id="cpu-unlock-vault" value="Unlock Vault" />
+                  </div>
+                  <div id="cpu-vault-padlock-locked" class="center-ns">
+                    <svg fill="#000000" height="80px" width="80px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512" xml:space="preserve">
+                      <g>
+                        <g>
+                          <path d="M435.2,204.8h-25.6v-51.2C409.6,68.77,340.83,0,256,0S102.4,68.77,102.4,153.6v51.2H76.8c-14.14,0-25.6,11.46-25.6,25.6v256c0,14.14,11.46,25.6,25.6,25.6h358.4c14.14,0,25.6-11.46,25.6-25.6v-256C460.8,216.26,449.34,204.8,435.2,204.8z M128,153.6c0-70.579,57.421-128,128-128s128,57.421,128,128v51.2H128V153.6z M435.2,486.4H76.8v-256h358.4V486.4z"/>
+                        </g>
+                      </g>
+                      <g>
+                        <g>
+                          <path d="M256,307.2c-21.205,0-38.4,17.195-38.4,38.4c0,16.691,10.718,30.763,25.6,36.053V435.2h25.6v-53.547c14.882-5.291,25.6-19.354,25.6-36.053C294.4,324.395,277.205,307.2,256,307.2z M256,358.4c-7.057,0-12.8-5.743-12.8-12.8s5.743-12.8,12.8-12.8c7.057,0,12.8,5.743,12.8,12.8S263.057,358.4,256,358.4z"/>
+                        </g>
+                      </g>
+                    </svg>
+                  </div>
+                  <div id="cpu-vault-padlock-unlocked" class="center-ns dn-l">
+                    <svg fill="#19a974" height="80px" width="80px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512" xml:space="preserve">
+                      <g>
+                        <g>
+                          <path d="M256,307.2c-21.205,0-38.4,17.195-38.4,38.4c0,16.691,10.718,30.763,25.6,36.053V435.2h25.6v-53.547c14.882-5.291,25.6-19.354,25.6-36.053C294.4,324.395,277.205,307.2,256,307.2z M256,358.4c-7.057,0-12.8-5.743-12.8-12.8s5.743-12.8,12.8-12.8c7.057,0,12.8,5.743,12.8,12.8S263.057,358.4,256,358.4z"/>
+                        </g>
+                      </g>
+                      <g>
+                        <g>
+                          <path d="M435.2,204.8H128v-51.2c0-70.579,57.421-128,128-128c61.815,0,113.519,44.049,125.414,102.4h25.882C395.085,55.381,332.092,0,256,0c-84.83,0-153.6,68.77-153.6,153.6v51.2H76.8c-14.14,0-25.6,11.46-25.6,25.6v256c0,14.14,11.46,25.6,25.6,25.6h358.4c14.14,0,25.6-11.46,25.6-25.6v-256C460.8,216.26,449.34,204.8,435.2,204.8z M435.2,486.4H76.8v-256h358.4V486.4z"/>
+                        </g>
+                      </g>
+                    </svg>
+                  </div>
+                </form>
+              </div>
+              <div id="timing-cpu-probe-array" class="flex-grow-1 ba br3 relative">
+                <div class="flex flex-column">
+                  <h3 class="mt0 pt3 ph3">Probing</h3>
+                  <table class="sticky-table">
+                    <thead>
+                      <tr>
+                        <th>probe array index</th>
+                        <th>load timeline</th>
+                      </tr>
+                    </thead>
+                    <tbody class="overflow-y-auto maxh-3">
+                      <tr class="cpu-probe">
+                          <td>0</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>1</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>2</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>3</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>4</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>5</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>6</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>7</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>8</td>
+                          <td></td>
+                      </tr>
+                      <tr class="cpu-probe">
+                          <td>9</td>
+                          <td></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div class="self-center">
+              <input type="checkbox" id="cpu-hide" /><label class="pl2" for="cpu-hide">Hide CPU details</label>
+            </div>
+            <div class="flex g2 relative">
+            <!-- CODE HERE? -->
+              <div class="flex-grow-1 ba br3">
+                <table class="w-100 h-100 dt--fixed">
+                  <tbody>
+                    <tr>
+                      <th>CPU Cache</th>
+                      <th>RAM</th>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-0"></td>
+                      <td id="cpu-ram-0" style="transition:background-color 0.15s ease-in">probeArray[0]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-1"></td>
+                      <td id="cpu-ram-1" style="transition:background-color 0.15s ease-in">probeArray[1]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-2"></td>
+                      <td id="cpu-ram-2" style="transition:background-color 0.15s ease-in">probeArray[2]</td> 
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-3"></td>
+                      <td id="cpu-ram-3" style="transition:background-color 0.15s ease-in">probeArray[3]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-4"></td>
+                      <td id="cpu-ram-4" style="transition:background-color 0.15s ease-in">probeArray[4]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-5"></td>
+                      <td id="cpu-ram-5" style="transition:background-color 0.15s ease-in">probeArray[5]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-6"></td>
+                      <td id="cpu-ram-6" style="transition:background-color 0.15s ease-in">probeArray[6]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-7"></td>
+                      <td id="cpu-ram-7" style="transition:background-color 0.15s ease-in">probeArray[7]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-8"></td>
+                      <td id="cpu-ram-8" style="transition:background-color 0.15s ease-in">probeArray[8]</td>
+                    </tr>
+                    <tr>
+                      <td id="cpu-cache-9"></td>
+                      <td id="cpu-ram-9" style="transition:background-color 0.15s ease-in">probeArray[9]</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div id="cpu-cover" class="absolute absolute--fill flex justify-center items-center bg--body ba br3 o-0 pointer-events-none">
+                Mysterious CPU
+              </div>
+            </div>
+            
+          </div>
+end 
+
 return <SimpleArticle article={ article } head={ Head }>
   <p class="i">
     This article is my submission for the Handmade Network's 2024 <a href="https://handmade.network/jam/learning-2024">Learning Jam</a>. As such, it is the from the perspective of a recent learner, NOT the perspective of an expert on CPUs or CPU vulnerabilities. I have attempted to verify the article's contents as well as I can, but please do not consider it an authoritative source.
@@ -319,14 +488,14 @@ char dereferenceAndLookup(char* p) {
     This is now exploitable via a timing attack. <b>Whichever index of <code>probeArray</code> loads fastest is the value of <code>*p</code>.</b>
   </p>
   <p>
-    You can see this in the demo below. Choose an address to run the function with, then click on the elements of <code>probeArray</code> to see how quickly they load.
+    You can see this in the demo below. Choose an address (index) to run the function with, then click 'Probe ProbeArray' to see how quickly each element loads. 
+    The result reveals what value was stored at that address (index). See if you can figure out the combination to the vault hidden in memory using this information.
   </p>
   <p>
-    <TODO>Actual demo instead of this sketch ha ha</TODO>
   </p>
-  <p>
-    <img class="maxw-6" src="number_demo.jpg" />
-  </p>
+  <div class="wide wide-sm">
+    <CPUDemo />
+  </div>
   <p class="i">
     Note for pedants: yes, I know that CPUs do not cache individual integers. I will address this later, I promise.
   </p>

--- a/site/spectre/index.luax
+++ b/site/spectre/index.luax
@@ -116,7 +116,7 @@ end
 
 
 function CPUDemo()
-  return  <div id="timing-demo-cpu" class="timing-demo flex flex-column g2">
+  return  <div id="cpu-demo" class="timing-demo flex flex-column g2">
             <div class="flex g2 items-stretch">
               <div class="flex flex-column g2 ba pa3 br3 overflow-hidden">
                 <h3 class="mt0">CPU</h3>

--- a/site/spectre/script.js
+++ b/site/spectre/script.js
@@ -10,6 +10,7 @@ const timingServerCoverCheckbox = document.querySelector("#timing-hide-server");
 const timingServerCover = document.querySelector("#timing-server-cover");
 
 const cpuSecret = [1,3,3,7];
+const cpuDemo = document.querySelector("#cpu-demo");
 const cpuSecretIndex = document.querySelector("#cpu-secret-index");
 const cpuLookup = document.querySelector("#cpu-lookup");
 const cpuProbe = document.querySelector("#cpu-probe");
@@ -284,9 +285,11 @@ cpuUnlockVault.addEventListener('click', e => {
       cpuVaultPadlockUnlocked.classList.remove("dn-l"); // Show
   }
 });
-cpuCoverCheckbox.addEventListener('change', e => {
-  cpuCPUCover.style.opacity = e.target.checked? 1 : 0;
+
+cpuCoverCheckbox.addEventListener("change", e => {
+  cpuDemo.classList.toggle("hide-cpu", e.target.checked);
 });
+cpuCoverCheckbox.checked = false;
 
 for (const cpuProbe of document.querySelectorAll(".cpu-probe")) {
   cpuProbe.children[1].appendChild(Timeline());

--- a/site/spectre/script.js
+++ b/site/spectre/script.js
@@ -9,6 +9,21 @@ const timingRows = document.querySelector("#timing-attempts");
 const timingServerCoverCheckbox = document.querySelector("#timing-hide-server");
 const timingServerCover = document.querySelector("#timing-server-cover");
 
+const cpuSecret = [1,3,3,7];
+const cpuSecretIndex = document.querySelector("#cpu-secret-index");
+const cpuLookup = document.querySelector("#cpu-lookup");
+const cpuProbe = document.querySelector("#cpu-probe");
+const cpuClearCache = document.querySelector("#cpu-clear-cache");
+const cpuUnlockVault = document.querySelector("#cpu-unlock-vault");
+const cpuVaultDigit0 = document.querySelector("#cpu-vault-0");
+const cpuVaultDigit1 = document.querySelector("#cpu-vault-1");
+const cpuVaultDigit2 = document.querySelector("#cpu-vault-2");
+const cpuVaultDigit3 = document.querySelector("#cpu-vault-3");
+const cpuVaultPadlockUnlocked = document.querySelector("#cpu-vault-padlock-unlocked");
+const cpuVaultPadlockLocked = document.querySelector("#cpu-vault-padlock-locked"); // cpu-vault-padlock-locked
+const cpuCoverCheckbox = document.querySelector("#cpu-hide");
+const cpuCPUCover = document.querySelector("#cpu-cover");
+
 function TimingRow() {
   return E("tr", ["attempt"], [
     E("td"),
@@ -167,3 +182,113 @@ timingButton.addEventListener("click", async () => {
 for (const attempt of timingDemo.querySelectorAll(".attempt")) {
   attempt.children[2].appendChild(Timeline());
 }
+
+
+cpuLookup.addEventListener('click', e => {
+  e.preventDefault();
+  let secretIndex = cpuSecretIndex.value;
+  if (secretIndex === "") {
+      return;
+  }
+  secretIndex = +secretIndex;
+  if (secretIndex < 0 || secretIndex > 6) {
+      return;
+  }
+  const probeArrayIndex = cpuSecret[secretIndex];
+  if (probeArrayIndex) {
+      const cacheCell = document.querySelector("#cpu-cache-" + probeArrayIndex);
+      cacheCell.innerText = "probeArray[" + probeArrayIndex + "]";
+      const ramCell = document.querySelector("#cpu-ram-" + probeArrayIndex);
+      ramCell.classList.add("bg-orange");
+      setTimeout(()=> {
+          ramCell.classList.remove("bg-orange");
+      }, 300);
+  }
+});
+cpuClearCache.addEventListener('click', e => {
+  e.preventDefault();
+  for (let i = 0; i <= 9; i += 1) {
+      const cacheCell = document.querySelector("#cpu-cache-" + i);
+      cacheCell.innerText = "";
+  }
+});
+cpuProbe.addEventListener('click', async (e) => {
+  e.preventDefault();
+  cpuProbe.setAttribute("disabled", "disabled");
+  const inCPUCache = [];
+  for (let i = 0; i <= 9; i += 1) {
+      if(document.querySelector("#cpu-cache-" + i).innerText.trim() !== "") {
+          inCPUCache.push(i);
+      }
+  }
+  let cpuProbeRows = document.querySelectorAll(".cpu-probe");
+  for (let i = 0; i <= 9; i += 1) {
+      const stages = [];
+      const speedUp = 4;
+      stages.push({name: "cpu_cache_lookup", duration: 500/speedUp, color: "bg-green"});
+      if (!inCPUCache.includes(i)) {
+          stages.push({name: "ram_lookup", duration: 1500/speedUp, color: "bg-red" });
+      }
+      const row = cpuProbeRows[i];
+      const playhead = row.querySelector(".timer-playhead");
+      const bars = row.querySelector(".timer-bars");
+      const display = row.querySelector(".timer-time");
+      let currentStageStartTime = 0;
+      let currentBar = row.querySelector(".timer-bar");
+      let currentStage = null;
+      function newStage(start, stage) {
+          const bar = E("div", ["timer-bar"]);
+          bar.classList.add(stage.color);
+          bars.appendChild(bar);
+          currentStageStartTime = start;
+          currentBar = bar;
+          currentStage = stage;
+      }
+      bars.innerHTML = "";
+      newStage(0, stages[0]);
+
+      const timer = new Timer(10000);
+      while (!timer.done()) {
+          await frame(() => {
+              playhead.style.left = `${timer.elapsedSec() * speedUp * SECOND_WIDTH_REM}rem`;
+              currentBar.style.width = `${(timer.elapsed() - currentStageStartTime) * speedUp / 1000 * SECOND_WIDTH_REM}rem`;
+              display.innerText = `${(timer.elapsedSec() * speedUp).toFixed(1)}s`;
+          });
+          if (timer.elapsed() >= currentStageStartTime + currentStage.duration) {
+              const newStageIndex = stages.indexOf(currentStage) + 1;
+              if (newStageIndex >= stages.length) {
+                  break;
+              }
+              newStage(timer.elapsed(), stages[newStageIndex]);
+          }
+      }
+  }
+  cpuProbe.removeAttribute("disabled");
+});
+cpuUnlockVault.addEventListener('click', e => {
+  e.preventDefault();
+  let digit0 = cpuVaultDigit0.value;
+  let digit1 = cpuVaultDigit1.value;
+  let digit2 = cpuVaultDigit2.value;
+  let digit3 = cpuVaultDigit3.value;
+  if (digit0 === "" || digit1 === "" || digit2 === "" || digit3 === "") {
+      return;
+  }
+  digit0 = +digit0;
+  digit1 = +digit1;
+  digit2 = +digit2;
+  digit3 = +digit3;
+  if (digit0 === cpuSecret[0] && digit1 === cpuSecret[1] && digit2 === cpuSecret[2] && digit3 === cpuSecret[3]) {
+    console.log(document.getElementById("cpu-vault-padlock-locked"));
+      cpuVaultPadlockLocked.classList.add("dn-l"); // Hide
+      cpuVaultPadlockUnlocked.classList.remove("dn-l"); // Show
+  }
+});
+cpuCoverCheckbox.addEventListener('change', e => {
+  cpuCPUCover.style.opacity = e.target.checked? 1 : 0;
+});
+
+for (const cpuProbe of document.querySelectorAll(".cpu-probe")) {
+  cpuProbe.children[1].appendChild(Timeline());
+}
+

--- a/site/spectre/style.css
+++ b/site/spectre/style.css
@@ -57,3 +57,11 @@ th {
 .timing-demo.hide-server .timer-bar {
   background-color: var(--border-color);
 }
+
+.timing-demo.hide-cpu #cpu-cover {
+  opacity: 1;
+}
+
+.timing-demo.hide-cpu .timer-bar {
+  background-color: var(--border-color);
+}


### PR DESCRIPTION
The [spectre article](https://bvisness.me/spectre/) lacks an interactive demo. This demo should show visually how the CPU cache affects load times and how this can leak information. This pull request includes a proposal for this demo.

~Aerek